### PR TITLE
Wrap TessBaseAPIRecognize() and some ResultIterator functions

### DIFF
--- a/helpers.go
+++ b/helpers.go
@@ -7,6 +7,14 @@ import (
 	"unsafe"
 )
 
+func gobool(b C.int) bool {
+	if b != 0 {
+		return true
+	}
+
+	return false
+}
+
 func cStringVectorToStringslice(cStringVector **C.char) []string {
 	// get pointer size to do iteration
 	cPtrSize := unsafe.Sizeof(cStringVector)


### PR DESCRIPTION
Wanted to wrap `ETEXT_DESC` as well, but it doesn't seem to be exposed in the C API.
