### PR TITLE
Fix calling NewTess() with an empty datapath argument

### DIFF
--- a/tesseract.go
+++ b/tesseract.go
@@ -44,15 +44,21 @@ func NewTess(datapath string, language string) (*Tess, error) {
 	tba := C.TessBaseAPICreate()
 
 	// prepare string for C call
-	cDatapath := C.CString(datapath)
-	defer C.free(unsafe.Pointer(cDatapath))
-
-	// prepare string for C call
 	cLanguage := C.CString(language)
 	defer C.free(unsafe.Pointer(cLanguage))
 
-	// initialize datapath and language on TessBaseAPI
-	res := C.TessBaseAPIInit3(tba, cDatapath, cLanguage)
+	var res C.int
+	if datapath != "" {
+		// prepare string for C call
+		cDatapath := C.CString(datapath)
+		defer C.free(unsafe.Pointer(cDatapath))
+
+		// initialize datapath and language on TessBaseAPI
+		res = C.TessBaseAPIInit3(tba, cDatapath, cLanguage)
+	} else {
+		res = C.TessBaseAPIInit3(tba, nil, cLanguage)
+	}
+
 	if res != 0 {
 		return nil, errors.New("could not initiate new Tess instance")
 	}

--- a/tesseract.go
+++ b/tesseract.go
@@ -39,6 +39,10 @@ func Version() string {
 // int TessBaseAPIInit3(TessBaseAPI* handle, const char* datapath, const char* language);
 
 // NewTess creates and returns a new tesseract instance.
+// When datapath is an empty string, the TESSDATA_PREFIX environment variable
+// is used. If it's empty, the compile-time TESSDATA_PREFIX constant is used
+// instead. If it was not defined, datapath is set to the current working
+// directory.
 func NewTess(datapath string, language string) (*Tess, error) {
 	// create new empty TessBaseAPI
 	tba := C.TessBaseAPICreate()
@@ -48,6 +52,7 @@ func NewTess(datapath string, language string) (*Tess, error) {
 	defer C.free(unsafe.Pointer(cLanguage))
 
 	var res C.int
+	// Tesseract ignores TESSDATA_PREFIX when datapath is not NULL
 	if datapath != "" {
 		// prepare string for C call
 		cDatapath := C.CString(datapath)


### PR DESCRIPTION
This PR makes passing an empty `datapath` to `NewTess()` actually pass `NULL` to `TessBaseAPIInit3()`. It's needed because passing `NULL` is the only way to make Tesseract use the compiled in `TESSDATA_PREFIX` constant as the datapath (and Go won't allow passing `nil` when the argument type is `string`).

---

Code used to determine the datapath in Tesseract can be found in [ccutil/mainblk.cpp](//github.com/tesseract-ocr/tesseract/blob/450efa68cd6719fe7e01f77952a5d7520ddd69c0/ccutil/mainblk.cpp#L58-L83).
